### PR TITLE
Fixed bug #72: add location modifies existing one

### DIFF
--- a/smart_farm_frontend/src/features/location/ui/LocationList.tsx
+++ b/smart_farm_frontend/src/features/location/ui/LocationList.tsx
@@ -81,7 +81,10 @@ export const LocationList: React.FC<{ locationsToDisplay?: Location[], isAdmin:b
                     size={25}
                     stroke={2}
                     color={"#199ff4"}
-                    onClick={() => setLocationModalOpen(true)}
+                    onClick={() => {
+                        setSelectedLocation(undefined);
+                        setLocationModalOpen(true);
+                    }}
                     style={{ cursor: "pointer" }}
                 />
                 }


### PR DESCRIPTION
Fixed bug that selectedLocation was not being reset when the "add" button is clicked. If the user had previously clicked the "edit" button on a location, the add new location from would hold that location's data.